### PR TITLE
GNOME3.10 Support

### DIFF
--- a/windowlist@o2net.cl/metadata.json
+++ b/windowlist@o2net.cl/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.6", "3.8"],
+"shell-version": ["3.6", "3.8", "3.10.0"],
 "uuid": "windowlist@o2net.cl",
 "name": "Window List",
 "description": "Add a window list to the top panel",

--- a/windowlist@o2net.cl/specialMenus.js
+++ b/windowlist@o2net.cl/specialMenus.js
@@ -698,8 +698,7 @@ WindowThumbnail.prototype = {
         }
         this._updateWindowOptions();
 
-        this.actor.add(this.windowOptions, {expand: false, x_fill: false,
-            x_align: St.Align.MIDDLE});
+        this.actor.insert_child_at_index(this.windowOptions, 0);
 
         // make the window options half-overlap this.actor.
         // Mainloop needed while we weight for height/width to be allocated.

--- a/windowlist@o2net.cl/specialMenus.js
+++ b/windowlist@o2net.cl/specialMenus.js
@@ -405,7 +405,7 @@ PopupMenuThumbnailItem.prototype = {
         PopupMenu.PopupBaseMenuItem.prototype._init.call(this, params);
 
         this.image = image;
-        this.addActor(this.image);
+        this.actor.add_child(this.image);
     }
 };
 
@@ -439,7 +439,7 @@ PopupMenuAppSwitcherItem.prototype = {
 
         this._refresh();
 
-        this.addActor(this.appContainer);
+        this.actor.add_child(this.appContainer);
     },
 
     setMetaWindow: function(metaWindow) {


### PR DESCRIPTION
Hi, these are just the very basics needed to get windowlist working in GNOME3.10 (confirmed using GNOME Shell 3.10.0.1)

The only issue you now have is the windowOptions being stuck on the left hand side, but I wanted to see where you wanted to go with that first. Also, the unicode characters that you're using are actually (for the most part) only supported in Windows specific fonts. i.e. restore/maximize.

My reasons for helping here are quite clear and selfish :) We're probably going to use this in SolusOS 2, albeit with windowOptions disabled (I just can't get used to them, would rather that on right click tbh :)) 
